### PR TITLE
Remove contradictory wording.

### DIFF
--- a/pep-draft.rst
+++ b/pep-draft.rst
@@ -814,13 +814,7 @@ Reference, except for these notes as listed in the table above:
    A server **must** return empty bytestrings from any attempt to
    read from an empty or exhausted input stream.
 
-2. Servers **must** support the optional "size" argument to ``readline()``,
-   but as in WSGI 1.0, they are allowed to omit support for it.
-
-   (In WSGI 1.0, the size argument was not supported, on the grounds that
-   it might have been complex to implement, and was not often used in
-   practice...  but then the ``cgi`` module started using it, and so
-   practical servers had to start supporting it anyway!)
+2. Servers **must** support the optional "size" argument to ``readline()``.
 
 3. Note that the ``hint`` argument to ``readline`` and ``readlines()``
    is optional for both caller and implementer.  The application is

--- a/pep-draft.rst
+++ b/pep-draft.rst
@@ -814,7 +814,7 @@ Reference, except for these notes as listed in the table above:
    A server **must** return empty bytestrings from any attempt to
    read from an empty or exhausted input stream.
 
-2. Servers **must** support the optional "size" argument to ``readline()``.
+2. Servers **must** support the optional ``hint`` argument to ``readline()``.
 
 3. Note that the ``hint`` argument to ``readline`` and ``readlines()``
    is optional for both caller and implementer.  The application is


### PR DESCRIPTION
The prose here was outright contradictory ("**must** support" followed by "may omit support").

This was probably hit because of the change of **should** to **must** through the document, combined with the redundant original wording.

I also removed the parenthetical remark because it has no place in this document now.
